### PR TITLE
Release v2.0.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,12 @@
+# Changelog
+
+## [2.0.3] - 2026-02-25
+
+### Bug Fixes
+
+- **scope:** configurable team_size label instead of hardcoded engineers (#7)
+- **deps:** upgrade lodash to 4.17.23 for CVE-2025-XXXX
+
+### Documentation
+
+- **tech-debt:** add TD-011 custom skills registry file

--- a/src/resume_as_code/__version__.py
+++ b/src/resume_as_code/__version__.py
@@ -1,3 +1,1 @@
-"""Version information for resume-as-code."""
-
-__version__ = "2.0.2"
+__version__ = "2.0.3"


### PR DESCRIPTION
## Release v2.0.3

### Version Bump
- Previous: `2.0.2`
- New: `2.0.3`
- Bump type: `patch`

### Changes
- **fix(scope):** configurable team_size label instead of hardcoded engineers (#7)
- **fix(deps):** upgrade lodash to 4.17.23 for CVE-2025-XXXX
- **docs(tech-debt):** add TD-011 custom skills registry file

---

**To release:** Merge this PR, then create and push a tag:
```bash
git checkout main && git pull
git tag v2.0.3
git push origin v2.0.3
```